### PR TITLE
Make sure different git references get different folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+- '0.10'
+deploy:
+  provider: npm
+  email: t.wiszniewski@gmail.com
+  api_key:
+    secure: FeAuMiUHX6oWGC/EgJ1gmdKQSMBUvY+9VIENY7e9SJI0A1E8NijFK91coYnygeigrvYh5e0qKoy34tPqoHW7CbI/ZRBM+K1slDq27Osva/0F8DGqWSWNx7xJG4iKbUZsqLJIGtncmkGrnzjtq6H0WmfNPiqQwkC7GgXalHpWA2Y=
+  on:
+    tags: true
+    all_branches: true
+    repo: tomekwi/napa-cache-filename

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# npm-cache-filename
+# napa-cache-filename
+
+This is a fork of [npm-cache-filename][], updated to see the difference between different references. It creates different folders for `https://github.com/tomekwi/napa-cache-filename#v1.0.0` and `...#v1.1.0`.
 
 Given a cache folder and url, return the appropriate cache folder.
 
 ## USAGE
 
 ```javascript
-var cf = require('npm-cache-filename');
+var cf = require('napa-cache-filename');
 console.log(cf('/tmp/cache', 'https://registry.npmjs.org:1234/foo/bar'));
 // outputs: /tmp/cache/registry.npmjs.org_1234/foo/bar
 ```
@@ -13,7 +15,7 @@ console.log(cf('/tmp/cache', 'https://registry.npmjs.org:1234/foo/bar'));
 As a bonus, you can also bind it to a specific root path:
 
 ```javascript
-var cf = require('npm-cache-filename');
+var cf = require('napa-cache-filename');
 var getFile = cf('/tmp/cache');
 
 console.log(getFile('https://registry.npmjs.org:1234/foo/bar'));

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a fork of [npm-cache-filename][], updated to see the difference between 
 
 Given a cache folder and url, return the appropriate cache folder.
 
+[npm-cache-filename]: https://www.npmjs.com/package/npm-cache-filename
+
 ## USAGE
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+ [![Build status](https://img.shields.io/travis/tomekwi/napa-cache-filename.svg?style=flat-square)](https://travis-ci.org/tomekwi/napa-cache-filename)
+
 # napa-cache-filename
 
 This is a fork of [npm-cache-filename][], updated to see the difference between different references. It creates different folders for `https://github.com/tomekwi/napa-cache-filename#v1.0.0` and `...#v1.1.0`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # napa-cache-filename
 
-This is a fork of [npm-cache-filename][], updated to see the difference between different references. It creates different folders for `https://github.com/tomekwi/napa-cache-filename#v1.0.0` and `...#v1.1.0`.
+This is a fork of [npm-cache-filename][], updated to create different folders for different references – as in `https://github.com/tomekwi/napa-cache-filename#v1.1.0` and `...#v1.1.1`.
+
+---
 
 Given a cache folder and url, return the appropriate cache folder.
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ function cf(root, u) {
   // Strip off any /-rev/... or ?rev=... bits
   var revre = /(\?rev=|\?.*?&rev=|\/-rev\/).*$/;;
   var parts = u.path.replace(revre, '').split('/').slice(1);;
+  // Make sure different git references get different folders
+  var hash;;
+  if (u.hash && (hash = u.hash.slice(1))) parts.push(hash);;
   var p = [root, h].concat(parts.map(function(part) {
     return encodeURIComponent(part).replace(/%/g, '_');;
   }));;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "napa-cache-filename",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Given a cache folder and url, return the appropriate cache folder.",
   "main": "index.js",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "npm-cache-filename",
+  "name": "napa-cache-filename",
   "version": "1.1.0",
   "description": "Given a cache folder and url, return the appropriate cache folder.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-cache-filename",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Given a cache folder and url, return the appropriate cache folder.",
   "main": "index.js",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/npm/npm-cache-filename"
+    "url": "git://github.com/tomekwi/napa-cache-filename"
   },
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "contributors": ["Tomek Wiszniewski <t.wiszniewski@gmail.com>"],
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/npm/npm-cache-filename/issues"
+    "url": "https://github.com/tomekwi/napa-cache-filename/issues"
   },
-  "homepage": "https://github.com/npm/npm-cache-filename"
+  "homepage": "https://github.com/tomekwi/napa-cache-filename"
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "git://github.com/npm/npm-cache-filename"
   },
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
+  "contributors": ["Tomek Wiszniewski <t.wiszniewski@gmail.com>"],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/npm/npm-cache-filename/issues"

--- a/test.js
+++ b/test.js
@@ -17,5 +17,7 @@ test('it does the thing it says it does', function(t) {
           '/tmp/foo_134/xyz')
   t.equal(cf("/tmp", "https://foo:134/xyz-rev/baz"),
           '/tmp/foo_134/xyz-rev/baz')
+  t.equal(cf("/tmp", "git://foo:134/xyz-rev/baz.git#master"),
+          '/tmp/foo_134/xyz-rev/baz.git/master')
   t.end();
 });;


### PR DESCRIPTION
Hi there,

I use the package [shama/napa](https://github.com/shama/napa), installing a lot from tagged private git repos. Alas, it turns out that different tags land in the same cached folder. Napa always installs the cached version when available – and in effect it's impossible to update any libraries!

I don't know if this change goes inline with the package's intent. If it does, please merge.

Cheers

P.S. Just wondering if the double semicolons are some sort of irony :) I've remembered you by a blog post about semicolon-freedom :)
