### PR TITLE
Make sure different git references get different folders

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ function cf(root, u) {
   // Strip off any /-rev/... or ?rev=... bits
   var revre = /(\?rev=|\?.*?&rev=|\/-rev\/).*$/;;
   var parts = u.path.replace(revre, '').split('/').slice(1);;
+  // Make sure different git references get different folders
+  var hash;;
+  if (u.hash && (hash = u.hash.slice(1))) parts.push(hash);;
   var p = [root, h].concat(parts.map(function(part) {
     return encodeURIComponent(part).replace(/%/g, '_');;
   }));;

--- a/test.js
+++ b/test.js
@@ -17,5 +17,7 @@ test('it does the thing it says it does', function(t) {
           '/tmp/foo_134/xyz')
   t.equal(cf("/tmp", "https://foo:134/xyz-rev/baz"),
           '/tmp/foo_134/xyz-rev/baz')
+  t.equal(cf("/tmp", "git://foo:134/xyz-rev/baz.git#master"),
+          '/tmp/foo_134/xyz-rev/baz.git/master')
   t.end();
 });;


### PR DESCRIPTION
Hi,

Different git tags (like `npm/npm#v1.0.0` and `npm/npm#v2.0.0`) used to land in the same cached folder. This PR fixes it.

Small print: This is a clean version of https://github.com/npm/npm-cache-filename/pull/1. I messed that one up, because I was new to GitHub back then. A PR on shama/napa https://github.com/shama/napa/pull/43 is waiting for this to get released.
